### PR TITLE
test: expose upstream codeception sprintf bug

### DIFF
--- a/tests/Unit/ReportPrinterSprintfBugTest.php
+++ b/tests/Unit/ReportPrinterSprintfBugTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebProject\Codeception\Module\AiReporter\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Validates that escaping a percent sign as `%%` works around the Codeception 5
+ * upstream ArgumentCountError in `Codeception\Reporter\ReportPrinter` using the
+ * `--report` cli flag.
+ */
+class ReportPrinterSprintfBugTest extends TestCase
+{
+    /**
+     * @dataProvider provideEscapedPercentInNameCases
+     */
+    public function testEscapedPercentInName(int $value): void
+    {
+        self::assertSame(1, $value);
+    }
+
+    /**
+     * @return array<string, array<int>>
+     */
+    public static function provideEscapedPercentInNameCases(): iterable
+    {
+        return [
+            // The %% is rendered as % by the Codeception ReportPrinter sprintf
+            '100%% safely escaped' => [1],
+        ];
+    }
+}

--- a/tests/Unit/ReportPrinterSprintfBugTest.php
+++ b/tests/Unit/ReportPrinterSprintfBugTest.php
@@ -7,9 +7,10 @@ namespace WebProject\Codeception\Module\AiReporter\Tests\Unit;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Validates that escaping a percent sign as `%%` works around the Codeception 5
- * upstream ArgumentCountError in `Codeception\Reporter\ReportPrinter` using the
- * `--report` cli flag.
+ * Exposes the upstream Codeception 5 ArgumentCountError in `Codeception\Reporter\ReportPrinter`
+ * using the `--report` cli flag when a test name contains a `%`.
+ *
+ * @see https://github.com/Codeception/Codeception/pull/6927
  */
 class ReportPrinterSprintfBugTest extends TestCase
 {
@@ -27,8 +28,8 @@ class ReportPrinterSprintfBugTest extends TestCase
     public static function provideEscapedPercentInNameCases(): iterable
     {
         return [
-            // The %% is rendered as % by the Codeception ReportPrinter sprintf
-            '100%% safely escaped' => [1],
+            // This test is expected to fail with `ArgumentCountError` due to a bug in Codeception ReportPrinter
+            '100% coverage' => [1],
         ];
     }
 }


### PR DESCRIPTION
This adds a unit test demonstrating the ArgumentCountError bug in Codeception ReportPrinter when formatting output with a % symbol. The test is currently intentionally failing and references https://github.com/Codeception/Codeception/pull/6927 until the bug is resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test coverage for a known Codeception compatibility issue occurring when test names contain percent signs with the report flag enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->